### PR TITLE
WIP: New pledge + thanks pages

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,7 +11,7 @@
     <%= javascript_include_tag "site" %>
     <link href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700" rel="stylesheet">
   </head>
-  <body>
+  <body class="<%= page_classes %>">
     <%= yield %>
   </body>
 </html>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Use the title from a page's frontmatter if it has one -->
-    <title><%= current_page.data.title || "Light House" %></title>
+    <title><%= current_page.data.title || "Power Pack Switch" %></title>
     <%= stylesheet_link_tag "site" %>
     <%= javascript_include_tag "site" %>
     <link href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700" rel="stylesheet">

--- a/source/layouts/school-pledge.erb
+++ b/source/layouts/school-pledge.erb
@@ -1,27 +1,5 @@
 <% wrap_layout :layout do %>
 
-<input type="checkbox" id="pledge-toggle">
-
-<section class="modal">
-  <label for="pledge-toggle">Close</label>
-  Switch to a green energy company
-  Fill in your contact details so that Power Pack can call you and take care of your switch.
-
-  Your full name [mandatory field]
-  Your telephone number [mandatory field]
-
-  If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank. [optional field]
-
-  Please confirm that you agree to
-  Power Pack calling you to arrange your switch
-  Switching to a green 100% renewable energy company
-  [school name] receiving a payment of [amount]
-
-  I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
-
-  [submit button]
-</section>
-
 <div class="banner">
   <div class="container">
     <header class="row">
@@ -48,8 +26,7 @@
 
         <span class="required-pledges"><%= current_page.data.pledges_needed %></span>
 
-        <p class="button"><label for="pledge-toggle">Pledge now</label>
-</p>
+        <p class="button"><a href="pledge">Pledge now</a></p>
 
         <p>We’ve set ourselves a target of getting <%= current_page.data.pledges_needed %> families to switch, which would mean <%= current_page.data.raising_money_for %>.</p>
 
@@ -127,7 +104,7 @@
 
         <span class="required-pledges"><%= current_page.data.pledges_needed %></span>
 
-        <p class="button"><label for="pledge-toggle">Pledge now</label></p>
+        <p class="button"><a href="pledge">Pledge now</a></p>
 
       </div>
     </section>

--- a/source/layouts/school-pledge.erb
+++ b/source/layouts/school-pledge.erb
@@ -126,5 +126,24 @@
   </div>
 </footer>
 
+<section class="pledge-modal">
+  Switch to a green energy company
+  Fill in your contact details so that Power Pack can call you and take care of your switch.
+
+  Your full name [mandatory field]
+  Your telephone number [mandatory field]
+
+  If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank. [optional field]
+
+  Please confirm that you agree to
+  Power Pack calling you to arrange your switch
+  Switching to a green 100% renewable energy company
+  [school name] receiving a payment of [amount]
+
+  I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
+
+  [submit button]
+</section>
+
 
 <% end %>

--- a/source/layouts/school-pledge.erb
+++ b/source/layouts/school-pledge.erb
@@ -1,5 +1,26 @@
 <% wrap_layout :layout do %>
 
+<input type="checkbox" id="pledge-toggle">
+
+<section class="modal">
+  Switch to a green energy company
+  Fill in your contact details so that Power Pack can call you and take care of your switch.
+
+  Your full name [mandatory field]
+  Your telephone number [mandatory field]
+
+  If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank. [optional field]
+
+  Please confirm that you agree to
+  Power Pack calling you to arrange your switch
+  Switching to a green 100% renewable energy company
+  [school name] receiving a payment of [amount]
+
+  I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
+
+  [submit button]
+</section>
+
 <div class="banner">
   <div class="container">
     <header class="row">
@@ -26,7 +47,8 @@
 
         <span class="required-pledges"><%= current_page.data.pledges_needed %></span>
 
-        <p class="button"><a href="#">Pledge now</a></p>
+        <p class="button"><label for="pledge-toggle">Pledge now</label>
+</p>
 
         <p>We’ve set ourselves a target of getting <%= current_page.data.pledges_needed %> families to switch, which would mean <%= current_page.data.raising_money_for %>.</p>
 
@@ -104,7 +126,7 @@
 
         <span class="required-pledges"><%= current_page.data.pledges_needed %></span>
 
-        <p class="button"><a href="#">Pledge now</a></p>
+        <p class="button"><label for="pledge-toggle">Pledge now</label></p>
 
       </div>
     </section>
@@ -125,25 +147,5 @@
     </div>
   </div>
 </footer>
-
-<section class="pledge-modal">
-  Switch to a green energy company
-  Fill in your contact details so that Power Pack can call you and take care of your switch.
-
-  Your full name [mandatory field]
-  Your telephone number [mandatory field]
-
-  If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank. [optional field]
-
-  Please confirm that you agree to
-  Power Pack calling you to arrange your switch
-  Switching to a green 100% renewable energy company
-  [school name] receiving a payment of [amount]
-
-  I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
-
-  [submit button]
-</section>
-
 
 <% end %>

--- a/source/layouts/school-pledge.erb
+++ b/source/layouts/school-pledge.erb
@@ -3,6 +3,7 @@
 <input type="checkbox" id="pledge-toggle">
 
 <section class="modal">
+  <label for="pledge-toggle">Close</label>
   Switch to a green energy company
   Fill in your contact details so that Power Pack can call you and take care of your switch.
 

--- a/source/pledge.html.erb
+++ b/source/pledge.html.erb
@@ -1,0 +1,26 @@
+<% wrap_layout :layout do %>
+
+<h1>Switch to a green energy company</h1>
+
+<p>Fill in your contact details so that Power Pack can call you and take care of your switch.</p>
+
+<form action="#" method="post">
+  <label>Your full name</label>
+  <input type="text" name="" value="" required>
+
+  <label>Your telephone number</label>
+  <input type="text" name="" value="" required>
+  <p>If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank.</p>
+  <label for="">Your current supplier</label>
+  <input type="text" name="" value="">
+
+  <p>Please confirm that you agree to Power Pack calling you to arrange your switch Switching to a green 100% renewable energy company [school name] receiving a payment of [amount]</p>
+
+  <label>
+    <input type="checkbox">
+    I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
+  </label>
+  <button type="button" name="button">Pledge!</button>
+</form>
+
+<% end %>

--- a/source/pledge.html.erb
+++ b/source/pledge.html.erb
@@ -1,4 +1,4 @@
-<section class="pledge-form">
+<section class="form-style">
   <h1>Switch to a green energy company</h1>
 
   <p>Fill in your contact details so that Power Pack can call you and take care of your switch.</p>
@@ -9,16 +9,16 @@
 
     <label>Your telephone number</label>
     <input type="text" name="" value="" required>
-    <p>If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank.</p>
     <label for="">Your current supplier</label>
+    If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank.
     <input type="text" name="" value="">
 
-    <p>Please confirm that you agree to Power Pack calling you to arrange your switch Switching to a green 100% renewable energy company [school name] receiving a payment of [amount]</p>
+    <p>Please confirm that you agree to Power Pack calling you to arrange your switch Switching to a green 100% renewable energy company and your school receiving a payment of £25</p>
 
     <label>
       <input type="checkbox">
-      I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
+      I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for us to receive a payment from Power Pack for referring me to this scheme.
     </label>
-    <button type="button" name="button">Pledge!</button>
+    <p class="button"><a href="thanks">Pledge</a></p>
   </form>
 </section>

--- a/source/pledge.html.erb
+++ b/source/pledge.html.erb
@@ -1,4 +1,4 @@
-<section class="form-style">
+<section class="modal-layout">
   <h1>Switch to a green energy company</h1>
 
   <p>Fill in your contact details so that Power Pack can call you and take care of your switch.</p>

--- a/source/pledge.html.erb
+++ b/source/pledge.html.erb
@@ -1,26 +1,24 @@
-<% wrap_layout :layout do %>
+<section class="pledge-form">
+  <h1>Switch to a green energy company</h1>
 
-<h1>Switch to a green energy company</h1>
+  <p>Fill in your contact details so that Power Pack can call you and take care of your switch.</p>
 
-<p>Fill in your contact details so that Power Pack can call you and take care of your switch.</p>
+  <form action="#" method="post">
+    <label>Your full name</label>
+    <input type="text" name="" value="" required>
 
-<form action="#" method="post">
-  <label>Your full name</label>
-  <input type="text" name="" value="" required>
+    <label>Your telephone number</label>
+    <input type="text" name="" value="" required>
+    <p>If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank.</p>
+    <label for="">Your current supplier</label>
+    <input type="text" name="" value="">
 
-  <label>Your telephone number</label>
-  <input type="text" name="" value="" required>
-  <p>If you know the name of your energy company then fill it in. If you don’t know it, it’s OK to leave this blank.</p>
-  <label for="">Your current supplier</label>
-  <input type="text" name="" value="">
+    <p>Please confirm that you agree to Power Pack calling you to arrange your switch Switching to a green 100% renewable energy company [school name] receiving a payment of [amount]</p>
 
-  <p>Please confirm that you agree to Power Pack calling you to arrange your switch Switching to a green 100% renewable energy company [school name] receiving a payment of [amount]</p>
-
-  <label>
-    <input type="checkbox">
-    I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
-  </label>
-  <button type="button" name="button">Pledge!</button>
-</form>
-
-<% end %>
+    <label>
+      <input type="checkbox">
+      I confirm that I am happy for Power Pack to call me and switch me to a green energy provider, and for [school] to receive a payment from Power Pack for referring me to this scheme. [tick box]
+    </label>
+    <button type="button" name="button">Pledge!</button>
+  </form>
+</section>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -312,6 +312,14 @@ table {
   }
 }
 
+.green-mission {
+  position: relative;
+  &:before {
+    @extend .background-plate;
+    background: rgba($green, 0.1);
+  }
+}
+
 section {
   &.answer {
     @media only screen and (min-width: $breakpoint-large) {
@@ -506,11 +514,11 @@ body {
   &.thanks_index {
     padding: 2rem 0;
     margin-bottom: 4rem;
-    background: $blue;
+    background: $blue;    
   }
 }
 
-section.form-style {
+section.modal-layout {
   max-width: 600px;
   padding: 2.4rem;
   background: $white;

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -90,9 +90,10 @@ ul li {
 
 .button {
   margin: 2rem 0 4rem 0;
-  a {
+  a,label {
+    display: inline-block;
     background: $white;
-    padding: 1.5rem 2rem;
+    padding: 1.2rem 1.4rem;
     color: $pink;
     font-weight: 500;
     @include border-radius(0.5em);
@@ -510,4 +511,16 @@ img {
     height: 500px;
   }
   background-size: cover;
+}
+
+.modal {
+  display: none;
+}
+
+#pledge-toggle {
+  &:checked {
+    ~ .modal {
+      display: block;
+    }
+  }
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -517,6 +517,28 @@ img {
   display: none;
 }
 
+section.modal {
+  position: fixed;
+  z-index: 10;
+
+  top: 0.4rem;
+  right: 0.4rem;
+  bottom: 0.4rem;
+  left: 0.4rem;
+
+  @media only screen and (min-width: $breakpoint-med) {
+    top: 2rem;
+    left: 50%;
+    margin-left: -300px;
+    bottom: 2rem;
+    max-width: 600px;
+  }
+  background: $white;
+  padding: 1.2rem;
+  border-radius: 0.2rem;
+  box-shadow: 0 0 200px $dark-grey;
+}
+
 #pledge-toggle {
   &:checked {
     ~ .modal {

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -523,20 +523,28 @@ section.modal {
 
   top: 0.4rem;
   right: 0.4rem;
-  bottom: 0.4rem;
   left: 0.4rem;
 
   @media only screen and (min-width: $breakpoint-med) {
     top: 2rem;
     left: 50%;
     margin-left: -300px;
-    bottom: 2rem;
     max-width: 600px;
   }
+  
   background: $white;
   padding: 1.2rem;
   border-radius: 0.2rem;
   box-shadow: 0 0 200px $dark-grey;
+
+  label[for="pledge-toggle"]{
+    float: right;
+  }
+
+  p {
+    font-size: 1rem;
+  }
+
 }
 
 #pledge-toggle {

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -513,7 +513,7 @@ img {
   background-size: cover;
 }
 
-.modal {
+.modal, input#pledge-toggle {
   display: none;
 }
 

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -25,14 +25,6 @@ h1,h2,h3,h4,h5,h6 {
   color: darken($blue,10);
 }
 
-h1 {
-  @media only screen and (min-width: $breakpoint-large) {
-    margin-top: 2.4rem;
-    font-size: 1.5rem;
-    line-height: 1.4;
-  }
-}
-
 h1,h2,h3 {
   @media only screen and (min-width: $breakpoint-large) {
     margin-top: 4rem;
@@ -320,14 +312,6 @@ table {
   }
 }
 
-.green-mission {
-  position: relative;
-  &:before {
-    @extend .background-plate;
-    background: rgba($green, 0.1);
-  }
-}
-
 section {
   &.answer {
     @media only screen and (min-width: $breakpoint-large) {
@@ -513,44 +497,49 @@ img {
   background-size: cover;
 }
 
-.modal, input#pledge-toggle {
-  display: none;
+body {
+  &.pledge_index {
+    padding: 2rem 0;
+    margin-bottom: 4rem;
+    background: $pink;
+  }
+  &.thanks_index {
+    padding: 2rem 0;
+    margin-bottom: 4rem;
+    background: $blue;
+  }
 }
 
-section.modal {
-  position: fixed;
-  z-index: 10;
-
-  top: 0.4rem;
-  right: 0.4rem;
-  left: 0.4rem;
-
-  @media only screen and (min-width: $breakpoint-med) {
-    top: 2rem;
-    left: 50%;
-    margin-left: -300px;
-    max-width: 600px;
-  }
-  
+section.form-style {
+  max-width: 600px;
+  padding: 2.4rem;
   background: $white;
-  padding: 1.2rem;
+  margin: 0 auto;
   border-radius: 0.2rem;
-  box-shadow: 0 0 200px $dark-grey;
-
-  label[for="pledge-toggle"]{
-    float: right;
+  h1 {
+    margin-top: 0.8rem;
+  }
+  label {
+    width: 100%;
+    display: inline-block;
+    font-weight: bolder;
+  }
+  label, p {
+    font-size: 1.2rem;
+  }
+  input:not([type="checkbox"]) {
+    display: block;
+    margin: 1rem 0 2rem 0;
+    font-size: 1.8rem;
+    color: $dark-grey;
+    padding: 0.4rem;
   }
 
-  p {
-    font-size: 1rem;
-  }
-
-}
-
-#pledge-toggle {
-  &:checked {
-    ~ .modal {
-      display: block;
+  p.button {
+    a {
+      background: $pink;
+      color: $white;
+      font-size: 1.8rem;
     }
   }
 }

--- a/source/thanks.html.erb
+++ b/source/thanks.html.erb
@@ -1,3 +1,10 @@
-<section class="form-style">
+<section class="modal-layout">
+  <h1>Thank you</h1>
+  <p>You’ve joined all the other families who have pledged to switch to a green energy company.</p>
+
+  <p>And you’ve brought us one step closer to our goal!</p>
+
+  <p><strong>One last thing before you go</strong></p>
+  <p>We want as many people to take part in Power Pack's green switch as possible, so please share with your family and friends.</p>
 
 </section>

--- a/source/thanks.html.erb
+++ b/source/thanks.html.erb
@@ -1,0 +1,3 @@
+<section class="form-style">
+
+</section>


### PR DESCRIPTION
Decided against a modal style overlay -- since it's fixed position, if the content overflows the modal then it'll be hidden. To fix this we could add a scroll within the modal, but that's not best practice.

Instead, I've split the Pledge form into a new page. I've also created a Thanks page.

The rub is: we can't use the content variables that are specific to the school when you've clicked through to Pledge and Thanks.